### PR TITLE
feat: 좌표 정보를 location_info.dart로 분리, 실측 거리 데이터 리팩토링

### DIFF
--- a/lib/function/PDRManager.dart
+++ b/lib/function/PDRManager.dart
@@ -41,7 +41,7 @@ class PDRManager {
       stepCount++;
 
       // Δx, Δy 갱신
-      final adjustedHeadingDeg = (headingDeg + 180) % 360;
+      final adjustedHeadingDeg = (headingDeg) % 360; //여기 수정해야 하는 거 아님?
       final rad = adjustedHeadingDeg * pi / 180.0;
       final dx = stepLength * sin(rad); // East
       final dy = stepLength * cos(rad); // North

--- a/lib/function/location_info.dart
+++ b/lib/function/location_info.dart
@@ -1,0 +1,113 @@
+// lib/function/location_info.dart
+import 'dart:ui';
+import 'dart:math' as Math;
+
+const double imageOriginWidth = 3508;
+const double imageOriginHeight = 1422;
+
+// ===== (A) 마커 좌표 / API 매핑 =====
+final List<Map<String, dynamic>> markerList = [
+  {"x": 3150, "y": 830}, //1
+  {"x": 3008, "y": 830}, //2
+  {"x": 2866, "y": 830}, //3
+  {"x": 2723, "y": 830}, //4
+  {"x": 2581, "y": 830}, //5
+  {"x": 2439, "y": 830}, //6
+  {"x": 2297, "y": 830}, //7
+  {"x": 2154, "y": 830}, //8
+  {"x": 2012, "y": 830}, //9
+  {"x": 1870, "y": 830}, //10
+  {"x": 1668, "y": 830}, //11
+  {"x": 1526, "y": 830}, //12
+  {"x": 1384, "y": 830}, //13
+  {"x": 1242, "y": 830}, //14
+  {"x": 1100, "y": 830}, //15
+  {"x": 958, "y": 830}, //16
+  {"x": 816, "y": 830}, //17
+  {"x": 674, "y": 830}, //18
+  {"x": 532, "y": 830}, //19
+  {"x": 390, "y": 830}, //20
+  {"x": 238, "y": 880}, //21
+  {"x": 2777, "y": 730}, //22
+  {"x": 2777, "y": 540}, //23
+  {"x": 1800, "y": 755}, //24
+  {"x": 1668, "y": 680}, //25
+  {"x": 1668, "y": 530}, //26
+  {"x": 1668, "y": 930}, //27
+  {"x": 1800, "y": 1000}, //28
+  {"x": 1800, "y": 1100}, //29
+];
+
+final List<int> markerApiValues = [
+  1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
+  11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+  21, 22, 23, 24, 25, 26, 27, 28, 29
+];
+
+// ===== (B) 실측 거리 데이터 (m) =====
+// List<int>를 키로 쓰면 같은 숫자쌍을 넣더라도 같은 키로 인식이 안됨 -> 업데이트 및 조회 불안정
+// record 타입으로 refactoring
+final Map<({int a, int b}), double> realDistances = {
+  (a: 21, b: 20): 2.7,
+  (a: 20, b: 19): 4.5,
+  (a: 19, b: 18): 4.5,
+  (a: 18, b: 17): 4.5,
+  (a: 17, b: 16): 4.5,
+  (a: 16, b: 15): 4.5,
+  (a: 15, b: 14): 4.5,
+  (a: 14, b: 13): 4.5,
+  (a: 13, b: 12): 4.5,
+  (a: 12, b: 11): 4.5,
+  (a: 11, b: 10): 4.5,
+  (a: 10, b: 9): 4.5,
+  (a: 9, b: 8): 4.5,
+  (a: 8, b: 7): 4.5,
+  (a: 7, b: 6): 4.5,
+  (a: 6, b: 5): 4.5,
+  (a: 5, b: 4): 4.5,
+  (a: 4, b: 3): 4.5,
+  (a: 3, b: 2): 4.5,
+  (a: 2, b: 1): 4.5,
+  (a: 10, b: 27): 2.73,
+  (a: 27, b: 28): 2.25,
+  (a: 28, b: 29): 2.45,
+  (a: 27, b: 26): 3.6,
+  (a: 26, b: 25): 5.4,
+  (a: 5, b: 24): 3.6,
+  (a: 24, b: 25): 5.4,
+};
+
+// ===== (C) CAD 좌표 ↔ 보정 유틸 =====
+
+// 특정 marker id의 CAD 좌표(px) 반환
+Offset markerPos(int id) {
+  final idx = markerApiValues.indexOf(id);
+  final m = markerList[idx];
+  return Offset((m['x'] as num).toDouble(), (m['y'] as num).toDouble());
+}
+
+// pxPerMeter 평균 계산
+double computePxPerMeter() {
+  List<double> values = [];
+  realDistances.forEach((pair, realM) {
+    final pos1 = markerPos(pair.a);
+    final pos2 = markerPos(pair.b);
+    final cadDistPx = (pos1 - pos2).distance;
+    final pxPerM = cadDistPx / realM;
+    values.add(pxPerM);
+  });
+  return values.reduce((a, b) => a + b) / values.length;
+}
+
+// 구간별 px/m 리스트 출력 (검증용)
+void printPxPerMeterStats() {
+  realDistances.forEach((pair, realM) {
+    final pos1 = markerPos(pair.a);
+    final pos2 = markerPos(pair.b);
+    final cadDistPx = (pos1 - pos2).distance;
+    final ratio = cadDistPx / realM;
+    print("구간 ${pair.a}-${pair.b}: CAD=${cadDistPx.toStringAsFixed(2)}px, "
+        "실측=${realM.toStringAsFixed(2)}m, "
+        "px/m=${ratio.toStringAsFixed(3)}");
+  });
+}

--- a/lib/screens/1. home_screen.dart
+++ b/lib/screens/1. home_screen.dart
@@ -1,3 +1,4 @@
+// lib/screens/home_screen.dart
 import 'package:flutter/material.dart';
 import 'package:flutter/foundation.dart'; // ValueListenable
 import 'dart:async';
@@ -9,97 +10,7 @@ import '../function/prediction_service.dart';
 import 'package:flutter_compass/flutter_compass.dart';
 import 'dart:math' as math;
 import 'package:midas_project/screens/place_info.dart';
-import 'package:midas_project/function/location_info.dart';
-
-// ===== (A) 마커 좌표 / API 매핑 =====
-final List<Map<String, dynamic>> markerList = [
-  {"x": 3150, "y": 830}, //1
-  {"x": 3008, "y": 830}, //2
-  {"x": 2866, "y": 830}, //3
-  {"x": 2723, "y": 830}, //4
-  {"x": 2581, "y": 830}, //5
-  {"x": 2439, "y": 830}, //6
-  {"x": 2297, "y": 830}, //7
-  {"x": 2154, "y": 830}, //8
-  {"x": 2012, "y": 830}, //9
-  {"x": 1870, "y": 830}, //10
-  {"x": 1668, "y": 830}, //11
-  {"x": 1526, "y": 830}, //12
-  {"x": 1384, "y": 830}, //13
-  {"x": 1242, "y": 830}, //14
-  {"x": 1100, "y": 830}, //15
-  {"x": 958, "y": 830}, //16
-  {"x": 816, "y": 830}, //17
-  {"x": 674, "y": 830}, //18
-  {"x": 532, "y": 830}, //19
-  {"x": 390, "y": 830}, //20
-  {"x": 238, "y": 880}, //21
-  {"x": 2777, "y": 730}, //22
-  {"x": 2777, "y": 540}, //23
-  {"x": 1800, "y": 755}, //24
-  {"x": 1668, "y": 680}, //25
-  {"x": 1668, "y": 530}, //26
-  {"x": 1668, "y": 930}, //27
-  {"x": 1800, "y": 1000}, //28
-  {"x": 1800, "y": 1100}, //29
-];
-
-final List<int> markerApiValues = [
-  1,2,3,4,5,6,7,8,9,10,
-  11,12,13,14,15,16,17,18,19,20,
-  21,22,23,24,25,26,27,28,29
-];
-
-// ===== (B) 실측 거리 데이터 (m) =====
-final Map<List<int>, double> realDistances = {
-  [21, 20]: 2.7,
-  [20, 19]: 4.5,
-  [19, 18]: 4.5,
-  [18, 17]: 4.5,
-  [17, 16]: 4.5,
-  [16, 15]: 4.5,
-  [15, 14]: 4.5,
-  [14, 13]: 4.5,
-  [13, 12]: 4.5,
-  [12, 11]: 4.5,
-  [11, 10]: 4.5,
-  [10, 9]: 4.5,
-  [9, 8]: 4.5,
-  [8, 7]: 4.5,
-  [7, 6]: 4.5,
-  [6, 5]: 4.5,
-  [5, 4]: 4.5,
-  [4, 3]: 4.5,
-  [3, 2]: 4.5,
-  [2, 1]: 4.5,
-  [10, 27]: 2.73,
-  [27, 28]: 2.25,
-  [28, 29]: 2.45,
-  [27, 26]: 3.6,
-  [26, 25]: 5.4,
-  [5, 24]: 3.6,
-  [24, 25]: 5.4,
-};
-
-// CAD 좌표 가져오기
-Offset _markerPos(int id) {
-  final idx = markerApiValues.indexOf(id);
-  final m = markerList[idx];
-  return Offset((m['x'] as num).toDouble(), (m['y'] as num).toDouble());
-}
-
-// pxPerMeter 자동 계산
-double computePxPerMeter() {
-  List<double> values = [];
-  realDistances.forEach((pair, realM) {
-    final pos1 = _markerPos(pair[0]);
-    final pos2 = _markerPos(pair[1]);
-    final cadDistPx = (pos1 - pos2).distance;
-    final pxPerM = cadDistPx / realM;
-    values.add(pxPerM);
-  });
-  return values.reduce((a, b) => a + b) / values.length;
-}
+import 'package:midas_project/function/location_info.dart'; // ✅ 좌표/스케일 정보 불러오기
 
 // ===== 네이버 현재위치 스타일 마커 =====
 class NaverCurrentLocationMarker extends StatelessWidget {
@@ -171,9 +82,6 @@ class _HeadingTrianglePainter extends CustomPainter {
   bool shouldRepaint(covariant CustomPainter oldDelegate) => false;
 }
 
-const double imageOriginWidth = 3508;
-const double imageOriginHeight = 1422;
-
 class HomeScreen extends StatefulWidget {
   const HomeScreen({
     super.key,
@@ -224,9 +132,6 @@ class _HomeScreenState extends State<HomeScreen> {
     // ✅ 실측 기반 자동 보정
     _pxPerMeter = computePxPerMeter();
     print("✅ 보정된 pxPerMeter = $_pxPerMeter");
-
-    // LocationService 초기화
-    Get.put(LocationService());
 
     // 방위(heading)
     _compassSub = FlutterCompass.events?.listen((event) {
@@ -417,14 +322,14 @@ class _HomeScreenState extends State<HomeScreen> {
                         final my = (m['y'] as num).toDouble();
 
                         final scaledLeft = (mx / imageOriginWidth) * displayWidth;
-                        final scaledTop  = (my / imageOriginHeight) * displayHeight;
+                        final scaledTop = (my / imageOriginHeight) * displayHeight;
 
                         final isCurrent = selectedPredictionIndex != null && markerApiValue == selectedPredictionIndex;
                         final markerSize = 20.0;
 
                         return Positioned(
                           left: scaledLeft - (markerSize / 2),
-                          top:  scaledTop  - (markerSize / 2),
+                          top: scaledTop - (markerSize / 2),
                           child: GestureDetector(
                             behavior: HitTestBehavior.opaque,
                             onTap: () => _openPlaceSheet(markerId: markerApiValue),
@@ -455,7 +360,7 @@ class _HomeScreenState extends State<HomeScreen> {
                       if (_fusedPx != null)
                         Positioned(
                           left: _fusedPx!.dx - 28,
-                          top:  _fusedPx!.dy - 28,
+                          top: _fusedPx!.dy - 28,
                           child: GestureDetector(
                             onTap: () => _openPlaceSheet(markerId: selectedPredictionIndex),
                             child: Column(


### PR DESCRIPTION
- homescreen 에 있던 위치 관련 정보들을 따로 dart 파일 만들어 분리 (홈 화면 코드 너무 길었음)
- 실측 거리 데이터를 본래의 List 형태가 아닌 record 형태로 리팩토링 -> 업데이트 및 조회 과정에서의 오류 방지