### PR TITLE
refactor : 마커 정보 받아오는 api 로직 수정

### DIFF
--- a/lib/function/location_service.dart
+++ b/lib/function/location_service.dart
@@ -43,8 +43,9 @@ class LocationService extends GetxController {
   final Rxn<LocationDto> location = Rxn<LocationDto>();
   final RxnString error = RxnString();
 
-  DateTime? _lastFetchedAt;
+  // 캐시 및 타임스탬프를 ID별로 관리하도록 수정
   final Map<int, LocationDto> _cacheById = {};
+  final Map<int, DateTime> _lastFetchedAt = {};
 
   @override
   void onInit() {
@@ -62,23 +63,29 @@ class LocationService extends GetxController {
   // 외부에서 marker id를 세팅
   void setMarkerId(int? id) => markerId.value = id;
 
-  // 개별 id 조회(캐시 우선)
+  // [수정됨] 개별 id 조회 (캐시 우선, 만료 시 개별 API 호출)
   Future<void> _loadById(int id) async {
     loading.value = true;
     error.value = null;
     try {
       final now = DateTime.now();
-      final isFresh =
-          _lastFetchedAt != null && now.difference(_lastFetchedAt!) < _ttl;
+      final lastFetched = _lastFetchedAt[id];
+      final isFresh = lastFetched != null && now.difference(lastFetched) < _ttl;
 
-      if (!isFresh || !_cacheById.containsKey(id)) {
-        // 상세 엔드포인트가 없다고 가정 → 목록 갱신 후 조회
-        await fetchAll(); // 필요 시 한 번에 캐시 갱신
+      // 1. 캐시에 있고 신선하면 캐시에서 바로 제공
+      if (isFresh && _cacheById.containsKey(id)) {
+        location.value = _cacheById[id];
+        return; // 여기서 함수 종료
       }
-      location.value = _cacheById[id];
-      if (location.value == null) {
-        // 목록에 없으면 서버 스키마가 달라졌을 수 있음 → 안전 처리
+
+      // 2. 캐시에 없거나 만료되었으면 서버에서 직접 조회
+      final fetchedLocation = await fetchByIdDirect(id);
+      if (fetchedLocation != null) {
+        location.value = fetchedLocation;
+      } else {
+        // 서버에서도 못 찾은 경우 (404 Not Found 등)
         error.value = '해당 위치(id=$id)를 찾을 수 없음';
+        location.value = null;
       }
     } catch (e) {
       error.value = e.toString();
@@ -88,39 +95,24 @@ class LocationService extends GetxController {
     }
   }
 
-  // 전체 목록 가져와 캐시/타임스탬프 갱신
-  Future<List<LocationDto>> fetchAll({int skip = 0, int limit = 100}) async {
-    final uri = Uri.parse('$_base/locations/?skip=$skip&limit=$limit');
-    final res = await http
-        .get(uri, headers: {'accept': 'application/json'}).timeout(_timeout);
-
-    if (res.statusCode != 200) {
-      throw Exception('GET $uri failed: ${res.statusCode}');
-    }
-
-    final List data = jsonDecode(res.body) as List;
-    final list = data
-        .map((e) => LocationDto.fromJson(e as Map<String, dynamic>))
-        .toList();
-
-    _cacheById
-      ..clear()
-      ..addEntries(list.map((e) => MapEntry(e.id, e)));
-    _lastFetchedAt = DateTime.now();
-    return list;
-  }
-
-  // 필요 시: 개별 상세 엔드포인트가 생기면 이 메서드를 사용
+  // [수정됨] 개별 상세 엔드포인트를 직접 호출하는 메서드
   Future<LocationDto?> fetchByIdDirect(int id) async {
     final uri = Uri.parse('$_base/locations/$id');
     final res = await http
         .get(uri, headers: {'accept': 'application/json'}).timeout(_timeout);
+
     if (res.statusCode == 200) {
       final dto =
           LocationDto.fromJson(jsonDecode(res.body) as Map<String, dynamic>);
-      _cacheById[id] = dto;
+      _cacheById[id] = dto; // 캐시 갱신
+      _lastFetchedAt[id] = DateTime.now(); // 타임스탬프 갱신
       return dto;
+    } else if (res.statusCode == 404) {
+      // 404 Not Found의 경우 null을 반환하여 '찾을 수 없음'을 명확히 함
+      return null;
+    } else {
+      // 그 외 다른 에러의 경우 예외 발생
+      throw Exception('GET $uri failed: ${res.statusCode}');
     }
-    return null;
   }
 }


### PR DESCRIPTION
- 기존 데이터베이스상의 모든 마커에 대한 상세 정보를 받아오고, 프론트 상에서 필터링 통해 해당되는 마커에 대한 정보를 가져오던 로직을 서버 상에서 해당되는 마커의 정보만을 받아올 수 있도록 수정

1. 많은 사용자가 서버에게 마커 정보를 요청했을 때, 모든 마커 정보를 많은 사용자에게 넘겨줄 경우 서버 과부하가 발생할 수 있음.
2. 사용자가 요청한 것은 사용자가 누른 해당 마커에 대한 상세 정보 뿐인데, 경우마다 모든 마커 정보를 로드하는 것은 불필요한 전달임.