### PR TITLE
refator : ID 타입을 String 기반으로 통일 (노드 및 위치 서비스 전반)

### DIFF
--- a/lib/function/location_info.dart
+++ b/lib/function/location_info.dart
@@ -1,4 +1,3 @@
-// lib/function/location_info.dart
 import 'dart:ui';
 import 'dart:convert';
 import 'package:flutter/services.dart' show rootBundle;
@@ -6,7 +5,7 @@ import 'package:flutter/foundation.dart'; // debugPrint
 
 /// 노드 정보
 class Node {
-  final int id;
+  final String id; // 문자열 ID
   final String name;
   final double x;
   final double y;
@@ -23,11 +22,15 @@ class Node {
 
 /// 엣지 정보
 class Edge {
-  final int from;
-  final int to;
+  final String from; // 문자열 ID
+  final String to;   // 문자열 ID
   final double distance;
 
-  Edge({required this.from, required this.to, required this.distance});
+  Edge({
+    required this.from,
+    required this.to,
+    required this.distance,
+  });
 }
 
 class LocationGraph {
@@ -36,30 +39,29 @@ class LocationGraph {
 
   LocationGraph({required this.nodes, required this.edges});
 
-  Node getNode(int id) => nodes.firstWhere((n) => n.id == id);
+  Node getNode(String id) =>
+      nodes.firstWhere((n) => n.id == id, orElse: () => throw Exception('노드 $id 없음'));
 
   /// CAD 좌표(px) 대신 → 실측 좌표(m) 기반 반환
-  Offset nodePos(int id) {
+  Offset nodePos(String id) {
     final n = getNode(id);
     return Offset(n.x, n.y);
   }
 }
 
 // ---------- 유틸 ----------
+
 String _clean(String s) {
   return s
-      .replaceAll('\ufeff', '') // BOM
+      .replaceAll('\ufeff', '') // BOM 제거
       .replaceAll('"', '')
       .replaceAll("'", '')
       .trim();
 }
 
-bool _isIntToken(String s) => RegExp(r'^\s*\d+\s*$').hasMatch(s);
-
-int? _tryInt(String s) => int.tryParse(_clean(s));
 double? _tryDouble(String s) => double.tryParse(_clean(s));
 
-/// CSV 로드 (문자 ID → 내부 정수 ID로 매핑)
+/// CSV 로드 (ID 문자열 그대로 사용)
 Future<LocationGraph> loadGraphFromCsv() async {
   final nodeCsv = await rootBundle.loadString('assets/data/nodes_final.csv');
   final edgeCsv = await rootBundle.loadString('assets/data/edges_final.csv');
@@ -72,64 +74,20 @@ Future<LocationGraph> loadGraphFromCsv() async {
     return LocationGraph(nodes: const [], edges: const []);
   }
 
-  // 1) 모든 토큰(노드 id 문자열) 수집
-  final Set<String> nodeIdTokens = {};
-  final List<List<String>> nodeRows = [];
-  final List<List<String>> edgeRows = [];
+  // ---------- 노드 파싱 ----------
+  final List<Node> nodes = [];
+  int nodeSkipped = 0;
 
-  // 노드
   for (final raw in nodeLines.skip(1)) {
     if (raw.trim().isEmpty) continue;
     final cols = raw.split(',');
+
     if (cols.length < 5) {
       debugPrint('[Graph][NODES][SKIP] 컬럼 수 부족: "$raw"');
       continue;
     }
-    final idTok = _clean(cols[0]);
-    nodeIdTokens.add(idTok);
-    nodeRows.add(cols);
-  }
 
-  // 엣지 (엣지에서 등장하는 토큰도 매핑에 포함)
-  for (final raw in edgeLines.skip(1)) {
-    if (raw.trim().isEmpty) continue;
-    final cols = raw.split(',');
-    if (cols.length < 3) {
-      debugPrint('[Graph][EDGES][SKIP] 컬럼 수 부족: "$raw"');
-      continue;
-    }
-    edgeRows.add(cols);
-    final fromTok = _clean(cols[0]);
-    final toTok = _clean(cols[1]);
-    nodeIdTokens.add(fromTok);
-    nodeIdTokens.add(toTok);
-  }
-
-  // 2) 정수/문자 토큰 분리 & 최대 정수 id 파악
-  int maxNumeric = -1;
-  for (final tok in nodeIdTokens) {
-    if (_isIntToken(tok)) {
-      final v = int.parse(tok);
-      if (v > maxNumeric) maxNumeric = v;
-    }
-  }
-
-  // 3) 문자 토큰에 새 정수 id 부여 (겹치지 않게 maxNumeric+1부터)
-  int nextId = maxNumeric + 1;
-  final Map<String, int> idMap = {};
-  for (final tok in nodeIdTokens) {
-    if (_isIntToken(tok)) {
-      idMap[tok] = int.parse(tok);
-    } else {
-      idMap[tok] = nextId++;
-    }
-  }
-
-  // 4) 노드 파싱 (모든 토큰을 매핑된 정수 id로 변환)
-  final List<Node> nodes = [];
-  int nodeSkipped = 0;
-  for (final cols in nodeRows) {
-    final idTok = _clean(cols[0]);
+    final id = _clean(cols[0]);
     final name = _clean(cols[1]);
     final x = _tryDouble(cols[2]);
     final y = _tryDouble(cols[3]);
@@ -137,56 +95,55 @@ Future<LocationGraph> loadGraphFromCsv() async {
 
     if (x == null || y == null) {
       nodeSkipped++;
-      debugPrint('[Graph][NODES][SKIP] 좌표 파싱 실패: x="${cols[2]}", y="${cols[3]}" (id="$idTok")');
+      debugPrint('[Graph][NODES][SKIP] 좌표 파싱 실패: id=$id');
       continue;
     }
-    final mappedId = idMap[idTok];
-    if (mappedId == null) {
-      nodeSkipped++;
-      debugPrint('[Graph][NODES][SKIP] id 매핑 실패: "$idTok"');
-      continue;
-    }
+
     nodes.add(Node(
-      id: mappedId,
-      name: name.isEmpty ? idTok : name, // 이름 비면 원래 토큰 사용
+      id: id,
+      name: name.isEmpty ? id : name,
       x: x,
       y: y,
       type: type.isEmpty ? 'marker' : type,
     ));
   }
-  debugPrint('[Graph] 노드 파싱 완료: kept=${nodes.length}, skipped=$nodeSkipped (문자 ID 포함 매핑 처리됨)');
 
-  // 5) 엣지 파싱
-  final nodeIdSet = nodes.map((n) => n.id).toSet();
+  debugPrint('[Graph] 노드 파싱 완료: ${nodes.length}개 (스킵 $nodeSkipped개)');
+
+  // ---------- 엣지 파싱 ----------
+  final Set<String> nodeIdSet = nodes.map((n) => n.id).toSet();
   final List<Edge> edges = [];
   int edgeSkipped = 0;
 
-  for (final cols in edgeRows) {
-    final fromTok = _clean(cols[0]);
-    final toTok = _clean(cols[1]);
+  for (final raw in edgeLines.skip(1)) {
+    if (raw.trim().isEmpty) continue;
+    final cols = raw.split(',');
+
+    if (cols.length < 3) {
+      debugPrint('[Graph][EDGES][SKIP] 컬럼 수 부족: "$raw"');
+      continue;
+    }
+
+    final from = _clean(cols[0]);
+    final to = _clean(cols[1]);
     final dist = _tryDouble(cols[2]);
 
     if (dist == null) {
       edgeSkipped++;
-      debugPrint('[Graph][EDGES][SKIP] distance 파싱 실패: "${cols[2]}"');
-      continue;
-    }
-    final fromId = idMap[fromTok];
-    final toId = idMap[toTok];
-    if (fromId == null || toId == null) {
-      edgeSkipped++;
-      debugPrint('[Graph][EDGES][SKIP] 토큰 매핑 실패: "$fromTok" -> "$toTok"');
-      continue;
-    }
-    if (!nodeIdSet.contains(fromId) || !nodeIdSet.contains(toId)) {
-      edgeSkipped++;
-      debugPrint('[Graph][EDGES][SKIP] 존재하지 않는 노드 참조: $fromTok($fromId) -> $toTok($toId)');
+      debugPrint('[Graph][EDGES][SKIP] 거리 파싱 실패: "$raw"');
       continue;
     }
 
-    edges.add(Edge(from: fromId, to: toId, distance: dist));
+    if (!nodeIdSet.contains(from) || !nodeIdSet.contains(to)) {
+      edgeSkipped++;
+      debugPrint('[Graph][EDGES][SKIP] 존재하지 않는 노드 참조: $from → $to');
+      continue;
+    }
+
+    edges.add(Edge(from: from, to: to, distance: dist));
   }
-  debugPrint('[Graph] 엣지 파싱 완료: kept=${edges.length}, skipped=$edgeSkipped');
+
+  debugPrint('[Graph] 엣지 파싱 완료: ${edges.length}개 (스킵 $edgeSkipped개)');
 
   return LocationGraph(nodes: nodes, edges: edges);
 }

--- a/lib/function/location_service.dart
+++ b/lib/function/location_service.dart
@@ -1,11 +1,11 @@
-// 서버 통신용 (네트워크 + DTO) 이므로 파일 이름 수정
+// 서버 통신용 (네트워크 + DTO)
 import 'dart:convert';
 import 'package:get/get.dart';
 import 'package:http/http.dart' as http;
 
 /// ===== DTO =====
 class LocationDto {
-  final int id;
+  final String id; // 🔧 int → String
   final String? locationName;
   final String? description;
   final int floor;
@@ -21,16 +21,16 @@ class LocationDto {
 
   factory LocationDto.fromJson(Map<String, dynamic> j) {
     return LocationDto(
-      id: j['id'] as int,
+      id: j['id'].toString(), // 🔧 안전하게 문자열 변환
       locationName: j['location_name'] as String?,
       description: j['description'] as String?,
-      floor: (j['floor'] as num).toInt(),
+      floor: (j['floor'] as num?)?.toInt() ?? 0,
       address: j['address'] as String? ?? '',
     );
   }
 }
 
-/// ===== 서비스(컨트롤러 통합) =====
+/// ===== 서비스 (GetX Controller) =====
 /// - markerId 변화 감지 → 자동 조회
 /// - 캐시/TTL 내장
 class LocationService extends GetxController {
@@ -38,20 +38,20 @@ class LocationService extends GetxController {
   static const Duration _timeout = Duration(seconds: 6);
   static const Duration _ttl = Duration(minutes: 5);
 
-  final RxnInt markerId = RxnInt();
+  final RxnString markerId = RxnString(); // 🔧 RxnInt → RxnString
   final RxBool loading = false.obs;
   final Rxn<LocationDto> location = Rxn<LocationDto>();
   final RxnString error = RxnString();
 
-  // 캐시 및 타임스탬프를 ID별로 관리하도록 수정
-  final Map<int, LocationDto> _cacheById = {};
-  final Map<int, DateTime> _lastFetchedAt = {};
+  // 캐시 및 타임스탬프 관리 (id: String 키)
+  final Map<String, LocationDto> _cacheById = {};
+  final Map<String, DateTime> _lastFetchedAt = {};
 
   @override
   void onInit() {
-    // markerId 변경을 자동 감지하여 데이터 재조회
-    ever<int?>(markerId, (id) async {
-      if (id == null) {
+    // markerId 변경 자동 감지 → 조회
+    ever<String?>(markerId, (id) async {
+      if (id == null || id.isEmpty) {
         location.value = null;
         return;
       }
@@ -60,30 +60,30 @@ class LocationService extends GetxController {
     super.onInit();
   }
 
-  // 외부에서 marker id를 세팅
-  void setMarkerId(int? id) => markerId.value = id;
+  /// 외부에서 marker ID 설정
+  void setMarkerId(String? id) => markerId.value = id;
 
-  // [수정됨] 개별 id 조회 (캐시 우선, 만료 시 개별 API 호출)
-  Future<void> _loadById(int id) async {
+  /// 캐시 우선 조회 (만료 시 서버 호출)
+  Future<void> _loadById(String id) async {
     loading.value = true;
     error.value = null;
+
     try {
       final now = DateTime.now();
       final lastFetched = _lastFetchedAt[id];
       final isFresh = lastFetched != null && now.difference(lastFetched) < _ttl;
 
-      // 1. 캐시에 있고 신선하면 캐시에서 바로 제공
+      // 캐시가 신선하면 그대로 사용
       if (isFresh && _cacheById.containsKey(id)) {
         location.value = _cacheById[id];
-        return; // 여기서 함수 종료
+        return;
       }
 
-      // 2. 캐시에 없거나 만료되었으면 서버에서 직접 조회
-      final fetchedLocation = await fetchByIdDirect(id);
-      if (fetchedLocation != null) {
-        location.value = fetchedLocation;
+      // 서버에서 조회
+      final fetched = await fetchByIdDirect(id);
+      if (fetched != null) {
+        location.value = fetched;
       } else {
-        // 서버에서도 못 찾은 경우 (404 Not Found 등)
         error.value = '해당 위치(id=$id)를 찾을 수 없음';
         location.value = null;
       }
@@ -95,23 +95,21 @@ class LocationService extends GetxController {
     }
   }
 
-  // [수정됨] 개별 상세 엔드포인트를 직접 호출하는 메서드
-  Future<LocationDto?> fetchByIdDirect(int id) async {
+  /// 단일 위치 정보 API 호출
+  Future<LocationDto?> fetchByIdDirect(String id) async {
     final uri = Uri.parse('$_base/locations/$id');
     final res = await http
-        .get(uri, headers: {'accept': 'application/json'}).timeout(_timeout);
+        .get(uri, headers: {'accept': 'application/json'})
+        .timeout(_timeout);
 
     if (res.statusCode == 200) {
-      final dto =
-          LocationDto.fromJson(jsonDecode(res.body) as Map<String, dynamic>);
-      _cacheById[id] = dto; // 캐시 갱신
-      _lastFetchedAt[id] = DateTime.now(); // 타임스탬프 갱신
+      final dto = LocationDto.fromJson(jsonDecode(res.body));
+      _cacheById[id] = dto;
+      _lastFetchedAt[id] = DateTime.now();
       return dto;
     } else if (res.statusCode == 404) {
-      // 404 Not Found의 경우 null을 반환하여 '찾을 수 없음'을 명확히 함
       return null;
     } else {
-      // 그 외 다른 에러의 경우 예외 발생
       throw Exception('GET $uri failed: ${res.statusCode}');
     }
   }

--- a/lib/screens/place_info.dart
+++ b/lib/screens/place_info.dart
@@ -6,7 +6,7 @@ import 'package:midas_project/function/location_service.dart';
 
 class SlideUpCard extends StatefulWidget {
   final VoidCallback onClose;
-  final int? markerId;
+  final String? markerId;
 
   const SlideUpCard({
     super.key,
@@ -24,35 +24,32 @@ class _SlideUpCardState extends State<SlideUpCard> {
   @override
   void initState() {
     super.initState();
-    // LocationService 인스턴스 가져오기 (없으면 생성)
-    _locationService = Get.find<LocationService>();
+    // LocationService 인스턴스 확보
+    try {
+      _locationService = Get.find<LocationService>();
+    } catch (_) {
+      _locationService = Get.put(LocationService());
+    }
 
-    // markerId가 있으면 해당 위치 정보 로드
-    if (widget.markerId != null) {
-      _locationService.setMarkerId(widget.markerId);
+    // ⚠️ 필드는 if ( != null )로 승격이 안 됨 → 로컬 변수로 받아서 체크
+    final mid = widget.markerId;
+    if (mid != null && mid.isNotEmpty) {
+      _locationService.setMarkerId(mid);
     }
   }
 
   @override
   Widget build(BuildContext context) {
-    // MediaQuery를 통해 안전 영역과 네비게이션 바 높이를 정확히 계산
-    final MediaQueryData mediaQuery = MediaQuery.of(context);
-    final double bottomPadding = mediaQuery.padding.bottom; // 안전 영역
-    final double bottomInset = mediaQuery.viewInsets.bottom; // 키보드 등
-
-    // 네비게이션 바가 있다면 추가 여백 (일반적으로 56-80px)
-    final double navigationBarHeight = 58.0; // 앱의 네비게이션 바 높이에 맞게 조정
-
-    // 총 하단 여백 계산
-    final double totalBottomGap =
-        bottomPadding + navigationBarHeight + bottomInset;
+    final mediaQuery = MediaQuery.of(context);
+    final double bottomPadding = mediaQuery.padding.bottom;
+    final double bottomInset = mediaQuery.viewInsets.bottom;
+    final double navigationBarHeight = 58.0;
+    final double totalBottomGap = bottomPadding + navigationBarHeight + bottomInset;
 
     return Align(
       alignment: Alignment.bottomCenter,
       child: Container(
-        margin: EdgeInsets.only(
-          bottom: totalBottomGap,
-        ),
+        margin: EdgeInsets.only(bottom: totalBottomGap),
         height: 227,
         padding: const EdgeInsets.all(16),
         decoration: BoxDecoration(
@@ -61,7 +58,6 @@ class _SlideUpCardState extends State<SlideUpCard> {
           border: Border(
             top: BorderSide(color: AppColors.grayscale.s100, width: 1),
           ),
-          // 그림자 추가로 더 자연스럽게
           boxShadow: [
             BoxShadow(
               color: Colors.black.withOpacity(0.1),
@@ -74,13 +70,11 @@ class _SlideUpCardState extends State<SlideUpCard> {
           final isLoading = _locationService.loading.value;
           final location = _locationService.location.value;
           final error = _locationService.error.value;
-          
+
           if (isLoading) {
-            return const Center(
-              child: CircularProgressIndicator(),
-            );
+            return const Center(child: CircularProgressIndicator());
           }
-          
+
           if (error != null) {
             return Column(
               crossAxisAlignment: CrossAxisAlignment.start,
@@ -89,15 +83,13 @@ class _SlideUpCardState extends State<SlideUpCard> {
                   mainAxisAlignment: MainAxisAlignment.spaceBetween,
                   children: [
                     Text("오류 발생", style: AppTextStyles.title6),
-                    Image.asset('assets/images/fill_star.png',
-                        width: 24, height: 24),
+                    Image.asset('assets/images/fill_star.png', width: 24, height: 24),
                   ],
                 ),
                 const SizedBox(height: 10),
                 Text(
                   error,
-                  style: AppTextStyles.body2_1
-                      .copyWith(color: AppColors.grayscale.s600),
+                  style: AppTextStyles.body2_1.copyWith(color: AppColors.grayscale.s600),
                 ),
                 const Spacer(),
                 Center(
@@ -109,13 +101,13 @@ class _SlideUpCardState extends State<SlideUpCard> {
               ],
             );
           }
-          
-          // 위치 정보가 없을 때 기본값 표시
+
+          // 위치 정보 fallback
           final locationName = location?.locationName ?? "위치 정보 없음";
           final description = location?.description ?? "위치 설명이 없습니다.";
           final floor = location?.floor ?? 0;
           final address = location?.address ?? "주소 정보 없음";
-          final markerId = widget.markerId ?? 0;
+          final markerIdLabel = widget.markerId ?? "-"; // ✅ 문자열 기본값으로 통일
 
           return Column(
             crossAxisAlignment: CrossAxisAlignment.start,
@@ -133,19 +125,19 @@ class _SlideUpCardState extends State<SlideUpCard> {
                           style: AppTextStyles.title6,
                           overflow: TextOverflow.ellipsis,
                         ),
-                        if (floor > 0)
-                          Text(
-                            "$floor층 | ID: $markerId",
-                            style: AppTextStyles.body2_1.copyWith(
-                              color: AppColors.grayscale.s500,
-                              fontSize: 12,
-                            ),
+                        Text(
+                          (floor > 0) ? "$floor층 | ID: $markerIdLabel" : "ID: $markerIdLabel",
+                          style: AppTextStyles.body2_1.copyWith(
+                            color: AppColors.grayscale.s500,
+                            fontSize: 12,
                           ),
+                          overflow: TextOverflow.ellipsis,
+                        ),
                       ],
                     ),
                   ),
-                  Image.asset('lib/assets/images/fill_star.png',
-                      width: 24, height: 24),
+                  // 경로 통일 (위쪽과 동일 경로 사용)
+                  Image.asset('assets/images/fill_star.png', width: 24, height: 24),
                 ],
               ),
               const SizedBox(height: 8),
@@ -169,7 +161,7 @@ class _SlideUpCardState extends State<SlideUpCard> {
                         height: 44,
                         child: ElevatedButton(
                           onPressed: () {
-                            // 출발 버튼 로직 구현
+                            // TODO: 출발 로직
                           },
                           style: ElevatedButton.styleFrom(
                             elevation: 0,
@@ -181,8 +173,7 @@ class _SlideUpCardState extends State<SlideUpCard> {
                           ),
                           child: Text(
                             "출발",
-                            style: AppTextStyles.body1_3
-                                .copyWith(color: AppColors.grayscale.s30),
+                            style: AppTextStyles.body1_3.copyWith(color: AppColors.grayscale.s30),
                           ),
                         ),
                       ),
@@ -193,7 +184,7 @@ class _SlideUpCardState extends State<SlideUpCard> {
                         height: 44,
                         child: ElevatedButton(
                           onPressed: () {
-                            // 도착 버튼 로직 구현
+                            // TODO: 도착 로직
                           },
                           style: ElevatedButton.styleFrom(
                             elevation: 0,
@@ -205,8 +196,7 @@ class _SlideUpCardState extends State<SlideUpCard> {
                           ),
                           child: Text(
                             "도착",
-                            style: AppTextStyles.body1_3
-                                .copyWith(color: AppColors.primary.s500),
+                            style: AppTextStyles.body1_3.copyWith(color: AppColors.primary.s500),
                           ),
                         ),
                       ),


### PR DESCRIPTION
### 🧭 변경 배경
- 중간 임시 노드(`A`, `C`, `K` 등) 추가로 인해 ID가 순수 숫자형이 아니게 되었음  
- 이를 반영하기 위해 앱 전반의 노드/마커/위치 식별자를 문자열로 통일  
- ID 매핑 로직 제거로 구조 단순화 및 유지보수성 향상  

---

### 🔧 주요 변경 내용 요약

1. location_info.dart
- 불필요한 id 매핑(`idMap`, `maxNumeric`) 제거 → CSV ID를 그대로 사용  
- `loadGraphFromCsv()` 단순화: CSV 내 ID를 문자열 그대로 로드  
- `Edge.from/to`도 `String` 타입으로 통일  

2. indoor_map_screen.dart
- 예측 결과(`result.num`)를 `.toString()` 후 사용하여 그래프 노드 탐색 안정화  
- 마커 클릭 시, 문자열 ID 기반으로 SlideUpCard 호출  

---

### ✅ 영향 범위
- **모델 학습/서버 통신 로직에는 영향 없음** (예측 결과는 int 그대로 수신)  
- **프론트/앱 단에서 String ID 처리만 변경됨**  
- FastAPI 서버는 `/locations/{id}`에서 `id: str` 수신으로 대응 필요  

---

### 📌 추후 개선사항
- **모델 학습 예측 결과가 String을 반환하는 것으로 확인 -> 서버에서 int형으로 변경할 필요 없이 전체 로직을 String으로 통합할 필요 있음**